### PR TITLE
Fix for Exploitable Gunpowder Can Recipe

### DIFF
--- a/scripts/Removal.zs
+++ b/scripts/Removal.zs
@@ -220,3 +220,5 @@ JEI.hideIngredient(<item:car:asphalt_slab>);
 JEI.hideIngredient(<item:car:asphalt_slope>);
 JEI.hideIngredient(<item:car:asphalt_slope_flat_upper>);
 JEI.hideIngredient(<item:car:asphalt_slope_flat_lower>);
+
+craftingTable.removeByName("arsenals_of_the_apocalypse:gunpowder");

--- a/scripts/item.zs
+++ b/scripts/item.zs
@@ -86,6 +86,7 @@ craftingTable.addShaped("fridge_dark", <item:cfm:fridge_dark>,
 
 // Can
 <recipetype:create:pressing>.addRecipe("can_press", [<item:arsenals_of_the_apocalypse:can>], <tag:items:forge:plates/aluminum>, 256);
+craftingTable.addShapeless("unpack_gunpowder_can", <item:minecraft:gunpowder> * 4, [<item:arsenals_of_the_apocalypse:gunpowder_can>]);
 
 // Canned Beetroot
 <recipetype:create:sequenced_assembly>.addRecipe(<recipetype:create:sequenced_assembly>.builder("canned_beetroot")


### PR DESCRIPTION
The proposed PR fixes an inconsistency regarding the _Gunpowder Can_ item.

As is, the can is created with one _Can_ and four  _Gunpowder_. However, the resultant item can then be crafted into nine _Gunpowder_, creating five additional _Gunpowder_.

![exploit1](https://github.com/TqLxQuanZ/DeceasedCraft/assets/46859011/0080c155-de3c-4853-a835-b009e1a30068)
![exploit2](https://github.com/TqLxQuanZ/DeceasedCraft/assets/46859011/363227ae-58d9-4f72-b56a-6b815c930a93)

### Proposed Change

1. Remove the `1x Gunpowder Can` -> `9x Gunpowder` recipe created by _Arsenal of the Apocolypse_.
2. Replace the recipe with `1x Gunpowder Can` -> `4x Gunpowder`.

![fixed1](https://github.com/TqLxQuanZ/DeceasedCraft/assets/46859011/0c1a50d9-ce01-4cc0-8a20-05a75a6080a7)
