### PR TITLE
Changed Recipe Sequence for minecraft:ender_pearl.

### DIFF
--- a/scripts/item.zs
+++ b/scripts/item.zs
@@ -34,9 +34,9 @@ craftingTable.addShaped("backpack", <item:backpacked:backpack>,
                                                       .require(<tag:items:forge:dusts/obsidian>)
                                                       .loops(4)
                                                       .addOutput(<item:minecraft:ender_pearl>, 1)
-                                                      .addStep<mods.createtweaker.FillingRecipe>((rb) => rb.require(<fluid:minecraft:lava> * 25))
-                                                      .addStep<mods.createtweaker.FillingRecipe>((rb) => rb.require(<fluid:minecraft:water> * 25))
                                                       .addStep<mods.createtweaker.CuttingRecipe>((rb) => rb.duration(50))
+                                                      .addStep<mods.createtweaker.FillingRecipe>((rb) => rb.require(<fluid:minecraft:water> * 25))
+                                                      .addStep<mods.createtweaker.FillingRecipe>((rb) => rb.require(<fluid:minecraft:lava> * 25))
 													  );
 
 


### PR DESCRIPTION
My original suggestion to fix issue #2 was incorrect, it seems like any `FillingRecipe` starting with `forge:dusts/obsidian` conflicts with the recipe for sturdy sheet, even if the liquids are different. I suppose this may be a bug with CreateTweaker or the Create mod itself.

Proposed fix:
Start with the `CuttingRecipe` and end by filling lava. Sequenced assembly recipes shouldn't end by filling water because the Thirst mod adds an NBT tag with the water purity to the final item, argh!